### PR TITLE
Convert to reflection type

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Package conv provides fast and intuitive conversions across Go types. This libra
   >
   > Output:
   > ```Go
-  > cannot infer conversion for non-pointer 0 (type int)
+  > cannot infer conversion for unchangeable 0 (type int)
   > 42
   > ```
 

--- a/example_test.go
+++ b/example_test.go
@@ -156,7 +156,7 @@ func ExampleInfer() {
 		fmt.Println("Failed!")
 	}
 	// Output:
-	// cannot infer conversion for non-pointer 0 (type int)
+	// cannot infer conversion for unchangeable 0 (type int)
 	// 42
 }
 

--- a/internal/testconv/infer.go
+++ b/internal/testconv/infer.go
@@ -7,7 +7,7 @@ import (
 
 func RunInferTests(t *testing.T, fn func(into, from interface{}) error) {
 	// Should work with all other assertions
-	t.Run("Assertions", func(t *testing.T) {
+	t.Run("Interface Assertions", func(t *testing.T) {
 		for _, a := range assertions {
 			for _, e := range a.Exps {
 
@@ -27,16 +27,38 @@ func RunInferTests(t *testing.T, fn func(into, from interface{}) error) {
 		}
 	})
 
+	t.Run("Reflection Assertions", func(t *testing.T) {
+		for _, a := range assertions {
+			for _, e := range a.Exps {
+
+				// Create a pointer from the exp value for inference
+				intoVal := reflect.New(reflect.ValueOf(e.Value()).Type())
+
+				// Infer conversion & dereference.
+				err := fn(intoVal, a.From)
+				got := intoVal.Elem().Interface()
+
+				if err = e.Expect(got, err); err != nil {
+					t.Fatalf("(FAIL) %v %v\n%v", a, e, err)
+				} else {
+					t.Logf("(PASS) %v %v", a, e)
+				}
+			}
+		}
+	})
+
 	// Touch the negative cases
 	t.Run("Negative", func(t *testing.T) {
 		type negativeTest struct {
 			into, from interface{}
 		}
 		tests := []negativeTest{
-			{nil, nil},                // kind invalid
-			{nil, (interface{})(nil)}, // from kind
-			{0, nil},                  // non ptr
-			{&struct{}{}, nil},        // struct fallthrough
+			{nil, nil},                     // kind invalid
+			{nil, (interface{})(nil)},      // from kind
+			{0, nil},                       // non ptr
+			{&struct{}{}, nil},             // struct fallthrough
+			{reflect.ValueOf(nil), nil}, // value invalid
+			{reflect.ValueOf("5"), nil}, // value not settable
 			{(*complex128)(nil), nil},
 			{(*interface{})(nil), nil},
 			{(*interface{})(nil), (interface{})(nil)},


### PR DESCRIPTION
This allows to convert to a `reflect.Value` by giving a `reflect.Type`.